### PR TITLE
Benchmarks for PreAggregationOperator

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/MemoryStateBackendBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/MemoryStateBackendBenchmark.java
@@ -54,7 +54,7 @@ public class MemoryStateBackendBenchmark extends StateBackendBenchmarkBase {
 
 	@Benchmark
 	public void stateBackends(MemoryStateBackendContext context) throws Exception {
-		IntLongApplications.reduceWithWindow(context.source, TumblingEventTimeWindows.of(Time.seconds(10_000)));
+		IntLongApplications.reduceWithWindow(context.source, TumblingEventTimeWindows.of(WindowBenchmarks.WINDOW_LENGTH));
 		context.execute();
 	}
 

--- a/src/main/java/org/apache/flink/benchmark/RocksStateBackendBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/RocksStateBackendBenchmark.java
@@ -54,7 +54,7 @@ public class RocksStateBackendBenchmark extends StateBackendBenchmarkBase {
 
 	@Benchmark
 	public void stateBackends(RocksStateBackendContext context) throws Exception {
-		IntLongApplications.reduceWithWindow(context.source, TumblingEventTimeWindows.of(Time.seconds(10_000)));
+		IntLongApplications.reduceWithWindow(context.source, TumblingEventTimeWindows.of(WindowBenchmarks.WINDOW_LENGTH));
 		context.execute();
 	}
 

--- a/src/main/java/org/apache/flink/benchmark/WindowBenchmarks.java
+++ b/src/main/java/org/apache/flink/benchmark/WindowBenchmarks.java
@@ -42,7 +42,11 @@ import java.io.IOException;
 @OperationsPerInvocation(value = WindowBenchmarks.RECORDS_PER_INVOCATION)
 public class WindowBenchmarks extends BenchmarkBase {
 
+	// IntegerLongSource produces records (logically) at rate 1 record per 1 ms, so 1_000_000 records will span over
+	// 1_000_000 milliseconds.
 	public static final int RECORDS_PER_INVOCATION = 7_000_000;
+	public static final Time WINDOW_LENGTH = Time.milliseconds(100_000);
+	public static final Time SLIDING_WINDOW_SLIDE = Time.milliseconds(10_000);
 
 	public static void main(String[] args)
 			throws RunnerException {
@@ -62,19 +66,19 @@ public class WindowBenchmarks extends BenchmarkBase {
 
 	@Benchmark
 	public void tumblingWindow(TimeWindowContext context) throws Exception {
-		IntLongApplications.reduceWithWindow(context.source, TumblingEventTimeWindows.of(Time.seconds(10_000)));
+		IntLongApplications.reduceWithWindow(context.source, TumblingEventTimeWindows.of(WINDOW_LENGTH));
 		context.execute();
 	}
 
 	@Benchmark
 	public void slidingWindow(TimeWindowContext context) throws Exception {
-		IntLongApplications.reduceWithWindow(context.source, SlidingEventTimeWindows.of(Time.seconds(10_000), Time.seconds(1000)));
+		IntLongApplications.reduceWithWindow(context.source, SlidingEventTimeWindows.of(WINDOW_LENGTH, SLIDING_WINDOW_SLIDE));
 		context.execute();
 	}
 
 	@Benchmark
 	public void sessionWindow(TimeWindowContext context) throws Exception {
-		IntLongApplications.reduceWithWindow(context.source, EventTimeSessionWindows.withGap(Time.seconds(500)));
+		IntLongApplications.reduceWithWindow(context.source, EventTimeSessionWindows.withGap(WINDOW_LENGTH));
 		context.execute();
 	}
 

--- a/src/main/java/org/apache/flink/benchmark/WindowBenchmarks.java
+++ b/src/main/java/org/apache/flink/benchmark/WindowBenchmarks.java
@@ -82,6 +82,12 @@ public class WindowBenchmarks extends BenchmarkBase {
 		context.execute();
 	}
 
+	@Benchmark
+	public void preAggregateTumblingWindow(TimeWindowContext context) throws Exception {
+		IntLongApplications.preAggregateWithTumblingWindow(context.source, TumblingEventTimeWindows.of(WINDOW_LENGTH));
+		context.execute();
+	}
+
 	public static class TimeWindowContext extends Context {
 		public final int numberOfElements = 1000;
 

--- a/src/main/java/org/apache/flink/benchmark/functions/IntLongApplications.java
+++ b/src/main/java/org/apache/flink/benchmark/functions/IntLongApplications.java
@@ -1,9 +1,19 @@
 package org.apache.flink.benchmark.functions;
 
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.benchmark.CollectSink;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.functions.aggregation.PreAggregationOperator;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.assigners.WindowAssigner;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.streaming.api.windowing.windows.Window;
+
+import java.io.Serializable;
 
 public class IntLongApplications {
     public static <W extends Window> void reduceWithWindow(
@@ -15,5 +25,69 @@ public class IntLongApplications {
                 .window(windowAssigner)
                 .reduce(new SumReduceIntLong())
                 .addSink(new CollectSink());
+    }
+
+    public static void preAggregateWithTumblingWindow(
+            DataStreamSource<IntegerLongSource.Record> source,
+            TumblingEventTimeWindows windowAssigner) {
+
+        source
+                .map(new MultiplyIntLongByTwo())
+                .transform(
+                        "pre-aggregate",
+                        TypeInformation.of(new TypeHint<Tuple3<Integer, TimeWindow, LongAccumulator>>() {
+                        }),
+                        new PreAggregationOperator<>(
+                                new RecordRecordVoidAggregateFunction(),
+                                record -> record.key,
+                                TypeInformation.of(Integer.class),
+                                TypeInformation.of(LongAccumulator.class),
+                                windowAssigner,
+                                false))
+                .map(new MapFunction<Tuple3<Integer, TimeWindow, LongAccumulator>, IntegerLongSource.Record>() {
+                    @Override
+                    public IntegerLongSource.Record map(Tuple3<Integer, TimeWindow, LongAccumulator> value) throws Exception {
+                        return new IntegerLongSource.Record(value.f0, value.f2.value);
+                    }
+                })
+                .keyBy(record -> record.key)
+                .window(windowAssigner)
+                .reduce(new SumReduceIntLong())
+                .addSink(new CollectSink());
+    }
+
+    public static class LongAccumulator {
+        public long value;
+
+        public LongAccumulator() {
+            this(0L);
+        }
+
+        public LongAccumulator(long value) {
+            this.value = value;
+        }
+    }
+
+    private static class RecordRecordVoidAggregateFunction
+            implements AggregateFunction<IntegerLongSource.Record, LongAccumulator, Void>, Serializable {
+        @Override
+        public LongAccumulator createAccumulator() {
+            return new LongAccumulator();
+        }
+
+        @Override
+        public void add(IntegerLongSource.Record value, LongAccumulator accumulator) {
+            accumulator.value += value.value;
+        }
+
+        @Override
+        public Void getResult(LongAccumulator accumulator) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public LongAccumulator merge(LongAccumulator a, LongAccumulator b) {
+            return new LongAccumulator(a.value + b.value);
+        }
     }
 }

--- a/src/main/java/org/apache/flink/benchmark/functions/IntegerLongSource.java
+++ b/src/main/java/org/apache/flink/benchmark/functions/IntegerLongSource.java
@@ -1,6 +1,7 @@
 package org.apache.flink.benchmark.functions;
 
 import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.watermark.Watermark;
 
 public class IntegerLongSource extends RichParallelSourceFunction<IntegerLongSource.Record> {
     public static final class Record {
@@ -48,6 +49,9 @@ public class IntegerLongSource extends RichParallelSourceFunction<IntegerLongSou
             synchronized (ctx.getCheckpointLock()) {
                 ctx.collectWithTimestamp(Record.of((int) (counter % numberOfKeys), counter), counter);
                 counter += parallelism;
+                if ((counter / parallelism) % (1024 * 16) == 0) {
+                    ctx.emitWatermark(new Watermark(counter));
+                }
             }
         }
         running = false;

--- a/src/main/java/org/apache/flink/benchmark/functions/IntegerLongSource.java
+++ b/src/main/java/org/apache/flink/benchmark/functions/IntegerLongSource.java
@@ -41,12 +41,13 @@ public class IntegerLongSource extends RichParallelSourceFunction<IntegerLongSou
 
     @Override
     public void run(SourceContext<Record> ctx) throws Exception {
-        long counter = 0;
+        final int parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
+        long counter = getRuntimeContext().getIndexOfThisSubtask();
 
         while (running && counter < numberOfElements) {
             synchronized (ctx.getCheckpointLock()) {
                 ctx.collectWithTimestamp(Record.of((int) (counter % numberOfKeys), counter), counter);
-                counter++;
+                counter += parallelism;
             }
         }
         running = false;


### PR DESCRIPTION
Most of the commits are from #1 

Added PreAggregationOperator benchmarks and trimmed window sizes in other benchmarks to more reasonable values. Trimming will probably brake benchmark results in codespeed.