### PR TITLE
Ignore empty parameters in benchmark name generation

### DIFF
--- a/save_jmh_result.py
+++ b/save_jmh_result.py
@@ -52,7 +52,8 @@ def readData(args):
             name = line[benchmarkIndex].split(".")[-1]
             if len(paramIndexes) > 0:
                 for paramIndex in paramIndexes:
-                    name += "." + line[paramIndex]
+                    if len(line[paramIndex]) > 0:
+                        name += "." + line[paramIndex]
 
             results.append({
                 'commitid': args.commit,


### PR DESCRIPTION
Previously benchmark names were sensitive to adding parameters to different benchmarks.
Now there will be no such problem, since empty parameters will be ignored.