### PR TITLE
[hotfix] Fix NoClassDefFoundError when running network related benchmarks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@ under the License.
 		<jmh.version>1.19</jmh.version>
 		<junit.version>4.12</junit.version>
 		<avro.version>1.8.2</avro.version>
+		<mockito.version>2.21.0</mockito.version>
 	</properties>
 
 	<repositories>
@@ -140,6 +141,13 @@ under the License.
 			<artifactId>flink-avro</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
+                <dependency>
+                        <groupId>org.mockito</groupId>
+                        <artifactId>mockito-core</artifactId>
+                        <version>${mockito.version}</version>
+                        <type>jar</type>
+                        <scope>test</scope>
+                </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Network benchmarks are no longer executed since 29th of April and checking the [Jenkins log](http://codespeed.dak8s.net:8080/job/flink-master-benchmarks/3699/console) we could see below error:

> java.lang.NoClassDefFoundError: org/mockito/stubbing/Answer
> 	at org.apache.flink.streaming.runtime.io.benchmark.StreamNetworkBenchmarkEnvironment.createInputGate(StreamNetworkBenchmarkEnvironment.java:262)

This is caused by FLINK-12199 where `StreamNetworkBenchmarkEnvironment` is modified to invoke methods of `InputChannelTestUtils` thus involving `org.mockito.stubbing.Answer`.

Since `mockito-core` is a test-scope dependency of `flink-runtime` thus not a transitive dependency to `flink-benchmarks`, we need to explicitly add `mockito-core` as a dependency in `flink-benchmarks` project to fix the issue.