### PR TITLE
Use maven profile to differentiate travis and jenkins run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ install:
 # files. The "mvn install" command will run by default during the "install"
 # phase by Travis, without the profile flag. Here we customize the install
 # phase to use the relevant profile.
-- mvn install -P travis -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+- mvn install -P test -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 script:
-- mvn test -P travis -B
+- mvn test -P test -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,9 @@
 language: java
-
+install:
+# Invoke the "travis" profile during Maven steps; see <profile> in pom.xml
+# files. The "mvn install" command will run by default during the "install"
+# phase by Travis, without the profile flag. Here we customize the install
+# phase to use the relevant profile.
+- mvn install -P travis -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+script:
+- mvn test -P travis -B

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ There're mainly two ways:
     -Dexec.executable=java -Dexec.args="-jar target/benchmarks.jar <benchmark_class>"
    ```
 
+We also support to run each benchmark once (with only one fork and one iteration) for testing, with below command:
+
+```
+mvn test -P test
+```
+
 ## Code structure
 
 Recommended code structure is to define all benchmarks in [Apache Flink](https://github.com/apache/flink)

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<flink.version>1.8-SNAPSHOT</flink.version>
+		<flink.version>1.9-SNAPSHOT</flink.version>
 		<java.version>1.8</java.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@ under the License.
 
 	<profiles>
 		<profile>
-			<id>travis</id>
+			<id>test</id>
 			<activation>
 				<activeByDefault>false</activeByDefault>
 			</activation>
@@ -197,41 +197,12 @@ under the License.
 							</arguments>
 						</configuration>
 					</plugin>
-
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<version>${maven.compiler.version}</version>
-						<configuration>
-							<source>${java.version}</source>
-							<target>${java.version}</target>
-						</configuration>
-					</plugin>
-
-					<!-- Generate MyPojo class from avro schema -->
-					<plugin>
-						<groupId>org.apache.avro</groupId>
-						<artifactId>avro-maven-plugin</artifactId>
-						<version>${avro.version}</version>
-						<executions>
-							<execution>
-								<phase>generate-sources</phase>
-								<goals>
-									<goal>schema</goal>
-								</goals>
-								<configuration>
-									<sourceDirectory>${project.basedir}/src/main/resources/avro</sourceDirectory>
-									<!--<outputDirectory>${project.basedir}/src/main/java/</outputDirectory>-->
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
 				</plugins>
 			</build>
 		</profile>
 
 		<profile>
-			<id>jenkins</id>
+			<id>benchmark</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
 			</activation>
@@ -294,37 +265,41 @@ under the License.
 							</execution>
 						</executions>
 					</plugin>
-
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-compiler-plugin</artifactId>
-						<version>${maven.compiler.version}</version>
-						<configuration>
-							<source>${java.version}</source>
-							<target>${java.version}</target>
-						</configuration>
-					</plugin>
-
-					<!-- Generate MyPojo class from avro schema -->
-					<plugin>
-						<groupId>org.apache.avro</groupId>
-						<artifactId>avro-maven-plugin</artifactId>
-						<version>${avro.version}</version>
-						<executions>
-							<execution>
-								<phase>generate-sources</phase>
-								<goals>
-									<goal>schema</goal>
-								</goals>
-								<configuration>
-									<sourceDirectory>${project.basedir}/src/main/resources/avro</sourceDirectory>
-									<!--<outputDirectory>${project.basedir}/src/main/java/</outputDirectory>-->
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
 				</plugins>
 			</build>
 		</profile>
 	</profiles>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven.compiler.version}</version>
+				<configuration>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
+				</configuration>
+			</plugin>
+
+			<!-- Generate MyPojo class from avro schema -->
+			<plugin>
+				<groupId>org.apache.avro</groupId>
+				<artifactId>avro-maven-plugin</artifactId>
+				<version>${avro.version}</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>schema</goal>
+						</goals>
+						<configuration>
+							<sourceDirectory>${project.basedir}/src/main/resources/avro</sourceDirectory>
+							<!--<outputDirectory>${project.basedir}/src/main/java/</outputDirectory>-->
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@ under the License.
 		<junit.version>4.12</junit.version>
 		<avro.version>1.8.2</avro.version>
 		<mockito.version>2.21.0</mockito.version>
+		<maven.exec.version>1.6.0</maven.exec.version>
+		<maven.compiler.version>3.1</maven.compiler.version>
 	</properties>
 
 	<repositories>
@@ -150,129 +152,179 @@ under the License.
                 </dependency>
 	</dependencies>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>run-benchmarks</id>
-						<goals>
-							<goal>exec</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<classpathScope>test</classpathScope>
-					<executable>java</executable>
-					<arguments>
-						<argument>-classpath</argument>
-						<classpath/>
-						<argument>org.openjdk.jmh.Main</argument>
-						<argument>-e</argument>
-						<argument>org.apache.flink.benchmark.full.*,org.apache.flink.state.benchmark.*</argument>
-						<argument>-rf</argument>
-						<argument>csv</argument>
-						<argument>.*</argument>
-					</arguments>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>exec-maven-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>test-benchmarks</id>
-						<phase>test</phase>
-						<goals>
-							<goal>exec</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<classpathScope>test</classpathScope>
-					<executable>java</executable>
-					<arguments>
-						<argument>-classpath</argument>
-						<classpath/>
-						<argument>org.openjdk.jmh.Main</argument>
-						<!--shouldFailOnError-->
-						<argument>-foe</argument>
-						<argument>true</argument>
-						<!--speed up tests-->
-						<argument>-f</argument>
-						<argument>1</argument>
-						<argument>-i</argument>
-						<argument>1</argument>
-						<argument>-wi</argument>
-						<argument>0</argument>
-						<argument>-rf</argument>
-						<argument>csv</argument>
-						<argument>.*</argument>
-					</arguments>
-				</configuration>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-shade-plugin</artifactId>
-				<version>3.2.0</version>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>shade</goal>
-						</goals>
+	<profiles>
+		<profile>
+			<id>travis</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>${maven.exec.version}</version>
+						<executions>
+							<execution>
+								<id>test-benchmarks</id>
+								<phase>test</phase>
+								<goals>
+									<goal>exec</goal>
+								</goals>
+							</execution>
+						</executions>
 						<configuration>
-							<finalName>benchmarks</finalName>
-							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-									<mainClass>org.openjdk.jmh.Main</mainClass>
-								</transformer>
-                                                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                                                        <resource>reference.conf</resource>
-                                                                </transformer>
-                                                                <!-- The service transformer is needed to merge META-INF/services files -->
-                                                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
-                                                                        <projectName>Apache Flink</projectName>
-                                                                </transformer>
-							</transformers>
+							<skip>${skipTests}</skip>
+							<classpathScope>test</classpathScope>
+							<executable>java</executable>
+							<arguments>
+								<argument>-classpath</argument>
+								<classpath/>
+								<argument>org.openjdk.jmh.Main</argument>
+								<!--shouldFailOnError-->
+								<argument>-foe</argument>
+								<argument>true</argument>
+								<!--speed up tests-->
+								<argument>-f</argument>
+								<argument>1</argument>
+								<argument>-i</argument>
+								<argument>1</argument>
+								<argument>-wi</argument>
+								<argument>0</argument>
+								<argument>-rf</argument>
+								<argument>csv</argument>
+								<argument>.*</argument>
+							</arguments>
 						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+					</plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
-			</plugin>
-
-			<!-- Generate MyPojo class from avro schema -->
-			<plugin>
-				<groupId>org.apache.avro</groupId>
-				<artifactId>avro-maven-plugin</artifactId>
-				<version>${avro.version}</version>
-				<executions>
-					<execution>
-						<phase>generate-sources</phase>
-						<goals>
-							<goal>schema</goal>
-						</goals>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>${maven.compiler.version}</version>
 						<configuration>
-							<sourceDirectory>${project.basedir}/src/main/resources/avro</sourceDirectory>
-							<!--<outputDirectory>${project.basedir}/src/main/java/</outputDirectory>-->
+							<source>${java.version}</source>
+							<target>${java.version}</target>
 						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+					</plugin>
+
+					<!-- Generate MyPojo class from avro schema -->
+					<plugin>
+						<groupId>org.apache.avro</groupId>
+						<artifactId>avro-maven-plugin</artifactId>
+						<version>${avro.version}</version>
+						<executions>
+							<execution>
+								<phase>generate-sources</phase>
+								<goals>
+									<goal>schema</goal>
+								</goals>
+								<configuration>
+									<sourceDirectory>${project.basedir}/src/main/resources/avro</sourceDirectory>
+									<!--<outputDirectory>${project.basedir}/src/main/java/</outputDirectory>-->
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
+			<id>jenkins</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>exec-maven-plugin</artifactId>
+						<version>${maven.exec.version}</version>
+						<executions>
+							<execution>
+								<id>run-benchmarks</id>
+								<goals>
+									<goal>exec</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<classpathScope>test</classpathScope>
+							<executable>java</executable>
+							<arguments>
+								<argument>-classpath</argument>
+								<classpath/>
+								<argument>org.openjdk.jmh.Main</argument>
+								<argument>-e</argument>
+								<argument>org.apache.flink.benchmark.full.*,org.apache.flink.state.benchmark.*</argument>
+								<argument>-rf</argument>
+								<argument>csv</argument>
+								<argument>.*</argument>
+							</arguments>
+						</configuration>
+					</plugin>
+
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>3.2.0</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<finalName>benchmarks</finalName>
+									<transformers>
+										<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+											<mainClass>org.openjdk.jmh.Main</mainClass>
+										</transformer>
+		                                                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+		                                                                        <resource>reference.conf</resource>
+		                                                                </transformer>
+		                                                                <!-- The service transformer is needed to merge META-INF/services files -->
+		                                                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+		                                                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+		                                                                        <projectName>Apache Flink</projectName>
+		                                                                </transformer>
+									</transformers>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<version>${maven.compiler.version}</version>
+						<configuration>
+							<source>${java.version}</source>
+							<target>${java.version}</target>
+						</configuration>
+					</plugin>
+
+					<!-- Generate MyPojo class from avro schema -->
+					<plugin>
+						<groupId>org.apache.avro</groupId>
+						<artifactId>avro-maven-plugin</artifactId>
+						<version>${avro.version}</version>
+						<executions>
+							<execution>
+								<phase>generate-sources</phase>
+								<goals>
+									<goal>schema</goal>
+								</goals>
+								<configuration>
+									<sourceDirectory>${project.basedir}/src/main/resources/avro</sourceDirectory>
+									<!--<outputDirectory>${project.basedir}/src/main/java/</outputDirectory>-->
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
Change of https://github.com/dataArtisans/flink-benchmarks/pull/17 added a new `execution` and attached it to the `test` phase. In our Jenkins configuration we don't add `-DskipTests` option thus will also run the newly added execution, which will mess up the benchmark result.

Simply adding `-DskipTests` to Jenkins configuration and making the `test-benchmark` execution aware of it could work, but this will also [require](https://stackoverflow.com/questions/2192660/maven-maven-exec-plugin-multiple-execution-configurations/31338366#31338366) maven version to be above 3.3.1 and using `mvn exec:exec@run-benchmark` for master run, which seems a little bit hack. So here we suggest to use the `profile` way to differentiate `travis` and `jenkins` run