### PR TITLE
[FLINK-11877] Add an input idle benchmark for two input operators

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/functions/QueuingLongSource.java
+++ b/src/main/java/org/apache/flink/benchmark/functions/QueuingLongSource.java
@@ -1,0 +1,35 @@
+package org.apache.flink.benchmark.functions;
+
+public class QueuingLongSource extends LongSource {
+
+	private static Object lock = new Object();
+
+	private static int currentRank = 1;
+
+	private final int rank;
+
+	public QueuingLongSource(int rank, long maxValue) {
+		super(maxValue);
+		this.rank = rank;
+	}
+
+	@Override
+	public void run(SourceContext<Long> ctx) throws Exception {
+		synchronized (lock) {
+			while (currentRank != rank) {
+				lock.wait();
+			}
+		}
+
+		super.run(ctx);
+
+		synchronized (lock) {
+			currentRank++;
+			lock.notifyAll();
+		}
+	}
+
+	public static void reset() {
+		currentRank = 1;
+	}
+}


### PR DESCRIPTION
Adds a high level benchmark based on DataStream API for two-input operators to track a potential regression when one input is idle.