### PR TITLE
[FLINK-12818] Improve stability of twoInputMapSink benchmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,23 +133,26 @@ under the License.
 			<artifactId>jmh-generator-annprocess</artifactId>
 			<version>${jmh.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-statebackend-rocksdb_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-avro</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
-                <dependency>
-                        <groupId>org.mockito</groupId>
-                        <artifactId>mockito-core</artifactId>
-                        <version>${mockito.version}</version>
-                        <type>jar</type>
-                        <scope>test</scope>
-                </dependency>
+		
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>${mockito.version}</version>
+			<type>jar</type>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,34 @@ under the License.
 			<artifactId>flink-avro</artifactId>
 			<version>${flink.version}</version>
 		</dependency>
-		
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-tests_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-examples-batch_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-cep_${scala.binary.version}</artifactId>
+			<version>${flink.version}</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>

--- a/src/main/java/org/apache/flink/benchmark/TwoInputBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/TwoInputBenchmark.java
@@ -57,8 +57,14 @@ public class TwoInputBenchmark extends BenchmarkBase {
 	public void twoInputMapSink(FlinkEnvironmentContext context) throws Exception {
 
 		StreamExecutionEnvironment env = context.env;
+
 		env.enableCheckpointing(CHECKPOINT_INTERVAL_MS);
 		env.setParallelism(1);
+
+		// Setting buffer timeout to 1 is an attempt to improve twoInputMapSink benchmark stability.
+		// Without 1ms buffer timeout, some JVM forks are much slower then others, making results
+		// unstable and unreliable.
+		env.setBufferTimeout(1);
 
 		long numRecordsPerInput = RECORDS_PER_INVOCATION / 2;
 		DataStreamSource<Long> source1 = env.addSource(new LongSource(numRecordsPerInput));


### PR DESCRIPTION
This is an attempt to improve twoInputMapSink benchmark stability. Local test show that for some unknown reason, without 1ms buffer timeout, some JVM forks are much slower then others, making results unstable.

