### PR TITLE
[FLINK-14118] Bump number of writer threads in network data skew Benchmark to 10

### DIFF
--- a/src/test/java/org/apache/flink/benchmark/DataSkewStreamNetworkThroughputBenchmarkExecutor.java
+++ b/src/test/java/org/apache/flink/benchmark/DataSkewStreamNetworkThroughputBenchmarkExecutor.java
@@ -67,8 +67,8 @@ public class DataSkewStreamNetworkThroughputBenchmarkExecutor extends BenchmarkB
 		// 1000 num of channels (subpartitions)
 		private final int channels = 1000;
 
-		// 4 writer threads
-		private final int writers = 4;
+		// 10 writer threads, to increase the load on the machine
+		private final int writers = 10;
 
 		@Setup
 		public void setUp() throws Exception {


### PR DESCRIPTION
Previous value of 4, was not showing the expected speed improvement on the faster benchmarking machine (compared to slower development laptops).

With this PR, results before the fix:

```
Benchmark                                                                  Mode  Cnt     Score      Error   Units
DataSkewStreamNetworkThroughputBenchmarkExecutor.networkSkewedThroughput  thrpt   15  7300.068 ± 4629.374  ops/ms
```

and after:
```

Benchmark                                                                  Mode  Cnt      Score      Error   Units
DataSkewStreamNetworkThroughputBenchmarkExecutor.networkSkewedThroughput  thrpt   15  20435.596 ± 1092.723  ops/ms
```

While with 4 writer threads, there was no difference on my laptop.

@wsry 