### PR TITLE
[FLINK-13846] Add benchmark of mapstate isEmpty

### DIFF
--- a/src/main/java/org/apache/flink/state/benchmark/MapStateBenchmark.java
+++ b/src/main/java/org/apache/flink/state/benchmark/MapStateBenchmark.java
@@ -102,6 +102,12 @@ public class MapStateBenchmark extends StateBenchmarkBase {
     }
 
     @Benchmark
+    public boolean mapIsEmpty(KeyValue keyValue) throws Exception {
+        keyedStateBackend.setCurrentKey(keyValue.setUpKey);
+        return mapState.isEmpty();
+    }
+
+    @Benchmark
     @OperationsPerInvocation(mapKeyCount)
     public void mapKeys(KeyValue keyValue, Blackhole bh) throws Exception {
         keyedStateBackend.setCurrentKey(keyValue.setUpKey);


### PR DESCRIPTION
Sine we have new API of `mapState#isEmpty()`, we should also have benchmarks on this.