### PR TITLE
Update flink version to 1.10 and increase max memory of the test jvm to 6g.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<flink.version>1.9-SNAPSHOT</flink.version>
+		<flink.version>1.10-SNAPSHOT</flink.version>
 		<java.version>1.8</java.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,7 @@ under the License.
 							<classpathScope>test</classpathScope>
 							<executable>java</executable>
 							<arguments>
+								<argument>-Xmx6g</argument>
 								<argument>-classpath</argument>
 								<classpath/>
 								<argument>org.openjdk.jmh.Main</argument>


### PR DESCRIPTION
When PR https://github.com/dataArtisans/flink-benchmarks/pull/31 was added, the corresponding dependent code of Flink was not checked in, so the PR didn't compile at the time. Unfortunately, the PR incurs one problem which make the following PR can't pass the precommit test. More specifically, the test case added by https://github.com/dataArtisans/flink-benchmarks/pull/31 consumes more memory than the default test JVM can supply. This PR tries to fix the problem by increase the max memory that the test JVM. The reason why I choose 6g is that the document of Travis says that the default test VM has 7.5g memory (https://docs.travis-ci.com/user/reference/overview/). I think 6g is reasonable choice.