### PR TITLE
[FLINK-14346] [serialization] Add string-heavy version of SerializationFrameworkMiniBenchmark

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/full/PojoSerializationBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/full/PojoSerializationBenchmark.java
@@ -1,0 +1,127 @@
+package org.apache.flink.benchmark.full;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
+import org.apache.flink.benchmark.BenchmarkBase;
+import org.apache.flink.benchmark.SerializationFrameworkMiniBenchmarks;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.formats.avro.typeutils.AvroSerializer;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.openjdk.jmh.annotations.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode({Mode.Throughput})
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class PojoSerializationBenchmark extends BenchmarkBase {
+
+    SerializationFrameworkMiniBenchmarks.MyPojo pojo;
+    org.apache.flink.benchmark.avro.MyPojo avroPojo;
+
+    ExecutionConfig config = new ExecutionConfig();
+    TypeSerializer<SerializationFrameworkMiniBenchmarks.MyPojo> pojoSerializer =
+            TypeInformation.of(SerializationFrameworkMiniBenchmarks.MyPojo.class).createSerializer(config);
+    TypeSerializer<SerializationFrameworkMiniBenchmarks.MyPojo> kryoSerializer =
+            new KryoSerializer<>(SerializationFrameworkMiniBenchmarks.MyPojo.class, config);
+    TypeSerializer<org.apache.flink.benchmark.avro.MyPojo> avroSerializer =
+            new AvroSerializer<>(org.apache.flink.benchmark.avro.MyPojo.class);
+
+    ByteArrayInputStream pojoBuffer;
+    ByteArrayInputStream avroBuffer;
+    ByteArrayInputStream kryoBuffer;
+
+
+    @Setup
+    public void setup() throws IOException {
+        pojo = new SerializationFrameworkMiniBenchmarks.MyPojo(
+                0,
+                "myName",
+                new String[] {"op1", "op2", "op3", "op4"},
+                new SerializationFrameworkMiniBenchmarks.MyOperation[] {
+                        new SerializationFrameworkMiniBenchmarks.MyOperation(1, "op1"),
+                        new SerializationFrameworkMiniBenchmarks.MyOperation(2, "op2"),
+                        new SerializationFrameworkMiniBenchmarks.MyOperation(3, "op3")},
+                1,
+                2,
+                3,
+                "null");
+        avroPojo = new org.apache.flink.benchmark.avro.MyPojo(
+                0,
+                "myName",
+                Arrays.asList("op1", "op2", "op3", "op4"),
+                Arrays.asList(
+                        new org.apache.flink.benchmark.avro.MyOperation(1, "op1"),
+                        new org.apache.flink.benchmark.avro.MyOperation(2, "op2"),
+                        new org.apache.flink.benchmark.avro.MyOperation(3, "op3")),
+                1,
+                2,
+                3,
+                "null");
+        pojoBuffer = new ByteArrayInputStream(write(pojoSerializer, pojo));
+        avroBuffer = new ByteArrayInputStream(write(avroSerializer, avroPojo));
+        kryoBuffer = new ByteArrayInputStream(write(kryoSerializer, pojo));
+    }
+
+    public static void main(String[] args)
+            throws RunnerException {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + PojoSerializationBenchmark.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+
+    @Benchmark
+    public byte[] writePojo() throws IOException {
+        return write(pojoSerializer, pojo);
+    }
+
+    @Benchmark
+    public byte[] writeAvro() throws IOException {
+        return write(avroSerializer, avroPojo);
+    }
+
+    @Benchmark
+    public byte[] writeKryo() throws IOException {
+        return write(kryoSerializer, pojo);
+    }
+
+    @Benchmark
+    public SerializationFrameworkMiniBenchmarks.MyPojo readPojo() throws IOException {
+        pojoBuffer.reset();
+        return pojoSerializer.deserialize(new DataInputViewStreamWrapper(pojoBuffer));
+    }
+
+    @Benchmark
+    public SerializationFrameworkMiniBenchmarks.MyPojo readKryo() throws IOException {
+        kryoBuffer.reset();
+        return kryoSerializer.deserialize(new DataInputViewStreamWrapper(kryoBuffer));
+    }
+
+    @Benchmark
+    public org.apache.flink.benchmark.avro.MyPojo readAvro() throws IOException {
+        avroBuffer.reset();
+        return avroSerializer.deserialize(new DataInputViewStreamWrapper(avroBuffer));
+    }
+
+    private <T> byte[] write(TypeSerializer<T> serializer, T value) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        DataOutputView out = new DataOutputViewStreamWrapper(buffer);
+        serializer.serialize(value, out);
+        return buffer.toByteArray();
+    }
+}

--- a/src/main/java/org/apache/flink/benchmark/full/StringSerializationBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/full/StringSerializationBenchmark.java
@@ -1,0 +1,100 @@
+package org.apache.flink.benchmark.full;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.benchmark.BenchmarkBase;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.openjdk.jmh.annotations.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode({Mode.Throughput})
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class StringSerializationBenchmark extends BenchmarkBase {
+
+    public static void main(String[] args)
+            throws RunnerException {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + StringSerializationBenchmark.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+
+    @Param({"ascii", "russian", "chinese"})
+    public String type;
+
+    @Param({"4", "128", "16384"})
+    public String lengthStr;
+
+    int length;
+    String input;
+    public static final char[] asciiChars = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890".toCharArray();
+    public static final char[] russianChars = "йцукенгшщзхъфывапролджэячсмитьбюЙЦУКЕНГШЩЗХЪФЫВАПРОЛДЖЭЯЧСМИТЬБЮ".toCharArray();
+    public static final char[] chineseChars = "的是不了人我在有他这为之大来以个中上们到国说和地也子要时道出而于就下得可你年生".toCharArray();
+
+    ExecutionConfig config = new ExecutionConfig();
+    TypeSerializer<String> serializer = TypeInformation.of(String.class).createSerializer(config);
+    ByteArrayInputStream serializedBuffer;
+    DataInputView serializedStream;
+
+    @Setup
+    public void setup() throws IOException {
+        length = Integer.parseInt(lengthStr);
+        switch (type) {
+            case "ascii":
+                input = generate(asciiChars, length);
+                break;
+            case "russian":
+                input = generate(russianChars, length);
+                break;
+            case "chinese":
+                input = generate(chineseChars, length);
+                break;
+            default:
+                throw new IllegalArgumentException(type + "charset is not supported");
+        }
+        byte[] stringBytes = stringWrite();
+        serializedBuffer = new ByteArrayInputStream(stringBytes);
+        serializedStream = new DataInputViewStreamWrapper(serializedBuffer);
+    }
+
+    @Benchmark
+    public byte[] stringWrite() throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        DataOutputView out = new DataOutputViewStreamWrapper(buffer);
+        serializer.serialize(input, out);
+        return buffer.toByteArray();
+    }
+
+    @Benchmark
+    public String stringRead() throws IOException {
+        serializedBuffer.reset();
+        return serializer.deserialize(serializedStream);
+    }
+
+    private String generate(char[] charset, int length) {
+        char[] buffer = new char[length];
+        Random random = new Random();
+        for (int i=0; i<length; i++) {
+            buffer[i] = charset[random.nextInt(charset.length)];
+        }
+        return new String(buffer);
+    }
+
+}


### PR DESCRIPTION
This PR is a follow-up performance benchmark for the [FLINK-14346](https://issues.apache.org/jira/browse/FLINK-14346) issue about perf improvement for `StringValue.writeString` and `StringValue.readString`. Main PR for the feature is here: https://github.com/apache/flink/pull/10358

Current benchmark results are:
```
Original:

Benchmark                                                  Mode  Cnt    Score    Error   Units
SerializationFrameworkMiniBenchmarks.serializerHeavyPojo  thrpt   30  100.689 ±  1.716  ops/ms
SerializationFrameworkMiniBenchmarks.serializerKryo       thrpt   30  211.890 ±  5.048  ops/ms
SerializationFrameworkMiniBenchmarks.serializerPojo       thrpt   30  473.830 ± 11.037  ops/ms
SerializationFrameworkMiniBenchmarks.serializerRow        thrpt   30  549.780 ± 11.578  ops/ms
SerializationFrameworkMiniBenchmarks.serializerTuple      thrpt   30  587.982 ±  8.941  ops/ms

----------

Improved:

Benchmark                                                  Mode  Cnt    Score   Error   Units
SerializationFrameworkMiniBenchmarks.serializerHeavyPojo  thrpt   30  121.078 ± 2.657  ops/ms
SerializationFrameworkMiniBenchmarks.serializerKryo       thrpt   30  220.956 ± 7.624  ops/ms
SerializationFrameworkMiniBenchmarks.serializerPojo       thrpt   30  445.025 ± 6.894  ops/ms
SerializationFrameworkMiniBenchmarks.serializerRow        thrpt   30  521.074 ± 9.481  ops/ms
SerializationFrameworkMiniBenchmarks.serializerTuple      thrpt   30  545.966 ± 8.708  ops/ms
```

Most of these results are kind of noisy, but the most important one, `serializerHeavyPojo` has +20% performance gain with high confidence.