### PR TITLE
[FLINK-15171] fix issue with netty shuffle buffer allocation skewing benchmark results

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/FlinkEnvironmentContext.java
+++ b/src/main/java/org/apache/flink/benchmark/FlinkEnvironmentContext.java
@@ -41,6 +41,8 @@ public class FlinkEnvironmentContext {
     protected Configuration createConfiguration() {
         final Configuration configuration = new Configuration();
         configuration.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, NUM_NETWORK_BUFFERS);
+        configuration.setString("taskmanager.network.memory.max", "8m");
+        configuration.setString("taskmanager.network.memory.min", "4m");
         return configuration;
     }
 


### PR DESCRIPTION
This is a follow-up to the upstream [FLINK-15171](https://github.com/apache/flink/pull/10529) PR.

Currently most of the benchmarks use a single `FlinkEnvironmentContext` to use for running test jobs. While running `SerializationFrameworkMiniBenchmarks` suite, I've found that there is still quite a lot of time spent on cluster initialization right inside the benchmarking code. The following image is  
`SerializationFrameworkMiniBenchmarks.serializerTuple` running with async-profiler:

![image](https://user-images.githubusercontent.com/999061/71091205-97959980-219c-11ea-9d5f-1b68e65b6765.png)

The giant hill on the left side is actually nothing more than netty shuffle buffer allocation (which is 1gb by default) and it takes quite a lot of time:

![image](https://user-images.githubusercontent.com/999061/71091292-c0b62a00-219c-11ea-960c-78a75b23c18d.png)

I propose lowering the shuffle buffer size in the `FlinkEnvironmentContext` from default 1gb to something more reasonable like 8m, so it will eliminate this skew in the benchmark results.

After this PR, flame graph for `SerializationFrameworkMiniBenchmarks.serializerTuple` looks much more representative, and the cluster init taking 10% of the time is gone:

![image](https://user-images.githubusercontent.com/999061/71092461-2c999200-219f-11ea-9e14-33da6523dc6b.png)


Other option may be to rework the `FlinkEnvironmentContext` in a way so it will directly invoke the `LocalExecutor`, starting the `MiniCluster` once per the whole microbenchmark suite. But looks like it may require changes in the upstream `LocalExecutor` code.