### PR TITLE
[FLINK-15171] string serialization benchmark to use proper i/o buffer implementation as on SerializationFrameworkMiniBenchmarks

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/full/OffheapInputWrapper.java
+++ b/src/main/java/org/apache/flink/benchmark/full/OffheapInputWrapper.java
@@ -1,0 +1,32 @@
+package org.apache.flink.benchmark.full;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.runtime.io.network.api.serialization.SpillingAdaptiveSpanningRecordDeserializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+
+import java.lang.reflect.Field;
+
+public class OffheapInputWrapper {
+    public SpillingAdaptiveSpanningRecordDeserializer<?> reader;
+    public Buffer buffer;
+    public DataInputView dataInput;
+
+    public OffheapInputWrapper(byte[] initialPayload) throws Exception {
+        reader = new SpillingAdaptiveSpanningRecordDeserializer<>(new String[0]);
+        MemorySegment segment = MemorySegmentFactory.allocateUnpooledOffHeapMemory(initialPayload.length, this);
+        segment.put(0, initialPayload);
+        buffer = new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE, true, initialPayload.length);
+        Field nonSpanningWrapper = reader.getClass().getDeclaredField("nonSpanningWrapper");
+        nonSpanningWrapper.setAccessible(true);
+        dataInput = (DataInputView) nonSpanningWrapper.get(reader);
+    }
+
+    public void reset() throws Exception {
+        reader.setNextBuffer(buffer);
+    }
+
+}

--- a/src/main/java/org/apache/flink/benchmark/full/StringSerializationBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/full/StringSerializationBenchmark.java
@@ -4,10 +4,8 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.benchmark.BenchmarkBase;
-import org.apache.flink.core.memory.DataInputView;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
-import org.apache.flink.core.memory.DataOutputView;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.*;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -15,8 +13,6 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 import org.openjdk.jmh.annotations.*;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -50,11 +46,13 @@ public class StringSerializationBenchmark extends BenchmarkBase {
 
     ExecutionConfig config = new ExecutionConfig();
     TypeSerializer<String> serializer = TypeInformation.of(String.class).createSerializer(config);
-    ByteArrayInputStream serializedBuffer;
-    DataInputView serializedStream;
+    DataOutputSerializer serializedStream;
+    OffheapInputWrapper offheapInput;
+
+    public static final int INVOCATIONS = 1000;
 
     @Setup
-    public void setup() throws IOException {
+    public void setup() throws Exception {
         length = Integer.parseInt(lengthStr);
         switch (type) {
             case "ascii":
@@ -69,23 +67,32 @@ public class StringSerializationBenchmark extends BenchmarkBase {
             default:
                 throw new IllegalArgumentException(type + "charset is not supported");
         }
-        byte[] stringBytes = stringWrite();
-        serializedBuffer = new ByteArrayInputStream(stringBytes);
-        serializedStream = new DataInputViewStreamWrapper(serializedBuffer);
+        serializedStream = new DataOutputSerializer(128);
+        DataOutputSerializer payloadWriter = new DataOutputSerializer(128);
+        for (int i = 0; i < INVOCATIONS; i++) {
+            serializer.serialize(input, payloadWriter);
+        }
+        byte[] payload = payloadWriter.getCopyOfBuffer();
+        offheapInput = new OffheapInputWrapper(payload);
     }
 
     @Benchmark
-    public byte[] stringWrite() throws IOException {
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        DataOutputView out = new DataOutputViewStreamWrapper(buffer);
-        serializer.serialize(input, out);
-        return buffer.toByteArray();
+    @OperationsPerInvocation(INVOCATIONS)
+    public int stringWrite() throws IOException {
+        serializedStream.pruneBuffer();
+        for (int i = 0; i < INVOCATIONS; i++) {
+            serializer.serialize(input, serializedStream);
+        }
+        return serializedStream.length();
     }
 
     @Benchmark
-    public String stringRead() throws IOException {
-        serializedBuffer.reset();
-        return serializer.deserialize(serializedStream);
+    @OperationsPerInvocation(INVOCATIONS)
+    public void stringRead(Blackhole bh) throws Exception {
+        offheapInput.reset();
+        for (int i = 0; i < INVOCATIONS; i++) {
+            bh.consume(serializer.deserialize(offheapInput.dataInput));
+        }
     }
 
     private String generate(char[] charset, int length) {


### PR DESCRIPTION
This is a follow-up to the upstream [FLINK-15171](https://github.com/apache/flink/pull/10529) PR.

Originally `PojoSerializationBenchmark` and `StringSerializationBenchmark` used simple jdk default `byte[]`-backed input-output streams and views to test the serialization performance. But this resulted in a severe performance mismatch with the e2e tests in `SerializationFrameworkMiniBenchmarks`: by default Flink is using own offheap-based implementation of memory operations, which has completely different performance characteristics.

So, for example, on `StringSerializationBenchmark` [FLINK-14346](https://issues.apache.org/jira/browse/FLINK-14346) implementation of string serialization heavily outperformed the original implementation, being faster up to 15 times. But on `SerializationFrameworkMiniBenchmarks` there was performance degradation instead.

In this PR we do the following improvements:
* we introduce an `OffheapInputWrapper` which is using exactly the same implementations of memory read operations as in default Flink with `HybridMemorySegment`
* we switch to `DataOutputSerializer` to match the default one used in Flink for memory write operations.
* both `StringSerializationBenchmark` and `PojoSerializationBenchmark` now use proper read-write primitives, matching the behavior of `SerializationFrameworkMiniBenchmarks`.

These improvements allowed to reliably reproduce the mysterious performance regression discussed in [FLINK-15171](https://github.com/apache/flink/pull/10529).