### PR TITLE
[hotfix] Remove useless `setCreateIfMissing`

### DIFF
--- a/src/main/java/org/apache/flink/state/benchmark/BackendUtils.java
+++ b/src/main/java/org/apache/flink/state/benchmark/BackendUtils.java
@@ -56,8 +56,6 @@ public class BackendUtils {
         File recoveryBaseDir = prepareDirectory(recoveryDirName, rootDir);
         File dbPathFile = prepareDirectory(dbDirName, rootDir);
         RocksDBResourceContainer resourceContainer = new RocksDBResourceContainer();
-        resourceContainer.getDbOptions().setCreateIfMissing(true);
-
         ColumnFamilyOptions columnOptions = new ColumnFamilyOptions();
         ExecutionConfig executionConfig = new ExecutionConfig();
         RocksDBKeyedStateBackendBuilder<Long> builder = new RocksDBKeyedStateBackendBuilder<>(


### PR DESCRIPTION
We don't need to call setCreateIfMissing explicitly since `RocksDBResourceContainer#getDbOptions` would add that. Moreover, every time we call `getDbOptions` we would initialize a native owned `DBOptions` once.