### PR TITLE
[FLINK-16042] Add benchmark listAppend to test add function in AppendingState

### DIFF
--- a/src/main/java/org/apache/flink/state/benchmark/ListStateBenchmark.java
+++ b/src/main/java/org/apache/flink/state/benchmark/ListStateBenchmark.java
@@ -120,6 +120,12 @@ public class ListStateBenchmark extends StateBenchmarkBase {
     }
 
     @Benchmark
+    public void listAppend(KeyValue keyValue) throws Exception {
+        keyedStateBackend.setCurrentKey(keyValue.setUpKey);
+        listState.add(keyValue.value);
+    }
+
+    @Benchmark
     public Iterable<Long> listGet(KeyValue keyValue) throws Exception {
         keyedStateBackend.setCurrentKey(keyValue.setUpKey);
         return listState.get();


### PR DESCRIPTION
As discussed in [issue47](https://github.com/dataArtisans/flink-benchmarks/issues/47), to test the performance of `void add(IN value)` in `AppendingState`, we need to add a new Benchmark here.

The result looks like below, 
```
# Run complete. Total time: 00:07:51

Benchmark                      (backendType)   Mode  Cnt     Score    Error   Units
ListStateBenchmark.listAppend           HEAP  thrpt   30  3024.019 ± 36.616  ops/ms
ListStateBenchmark.listAppend        ROCKSDB  thrpt   30   315.488 ±  7.003  ops/ms
```
(Just to prove this works since I don't have a benchmark machine.)