### PR TITLE
[FLINK-15103] Set number of network buffers to 1000

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/FlinkEnvironmentContext.java
+++ b/src/main/java/org/apache/flink/benchmark/FlinkEnvironmentContext.java
@@ -15,7 +15,7 @@ import static org.openjdk.jmh.annotations.Scope.Thread;
 @State(Thread)
 public class FlinkEnvironmentContext {
 
-    public static final int NUM_NETWORK_BUFFERS = 32768; // this value is temporally set to the same as before flip49
+    public static final int NUM_NETWORK_BUFFERS = 1000;
 
     public final StreamExecutionEnvironment env = getStreamExecutionEnvironment();
 


### PR DESCRIPTION
With fewer number of buffers benchmarks should spend less time on initialisation and it should free up more memory for the benchmarks. 1000 buffers should be enough for all of the benchmarks, as they are executed on a single machine with low parallelism.