### PR TITLE
[FLINK-16019][benchmark] use NoRestart in CFRO benchmark

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/ContinuousFileReaderOperatorBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/ContinuousFileReaderOperatorBenchmark.java
@@ -19,6 +19,7 @@ package org.apache.flink.benchmark;
 
 import joptsimple.internal.Strings;
 import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileInputSplit;
@@ -58,6 +59,7 @@ public class ContinuousFileReaderOperatorBenchmark extends BenchmarkBase {
     @Benchmark
     public void readFileSplit(FlinkEnvironmentContext context) throws Exception {
         StreamExecutionEnvironment env = context.env;
+        env.setRestartStrategy(new RestartStrategies.NoRestartStrategyConfiguration());
         env
                 .enableCheckpointing(100)
                 .setParallelism(1)

--- a/src/main/java/org/apache/flink/benchmark/ContinuousFileReaderOperatorBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/ContinuousFileReaderOperatorBenchmark.java
@@ -26,7 +26,7 @@ import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperator;
+import org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperatorFactory;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.functions.source.TimestampedFileInputSplit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -65,7 +65,7 @@ public class ContinuousFileReaderOperatorBenchmark extends BenchmarkBase {
                 .setParallelism(1)
                 .addSource(new MockSourceFunction())
                 .transform("fileReader", TypeInformation.of(String.class),
-                        new ContinuousFileReaderOperator<>(new MockInputFormat()))
+                        new ContinuousFileReaderOperatorFactory<>(new MockInputFormat()))
                 .addSink(new DiscardingSink<>());
 
         env.execute();


### PR DESCRIPTION
There is an error currently in `ContinuousFileReaderOperator#dispose` which fails a single job run.
But the benchmark uses the default restart strategy which leads to indefinite restarts.
This PR changes restart strategy to NoRestart.

(CI failure after the 1st commit is the desired result (as long as there is an error in `ContinuousFileReaderOperator`))