### PR TITLE
[FLINK-17056][JMH] fix main methods running unrelated benchmarks

### DIFF
--- a/src/main/java/org/apache/flink/benchmark/AsyncWaitOperatorBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/AsyncWaitOperatorBenchmark.java
@@ -57,7 +57,7 @@ public class AsyncWaitOperatorBenchmark extends BenchmarkBase {
 		throws RunnerException {
 		Options options = new OptionsBuilder()
 			.verbosity(VerboseMode.NORMAL)
-			.include(".*" + AsyncWaitOperatorBenchmark.class.getSimpleName() + ".*")
+			.include(".*" + AsyncWaitOperatorBenchmark.class.getCanonicalName() + ".*")
 			.build();
 
 		new Runner(options).run();

--- a/src/main/java/org/apache/flink/benchmark/BlockingPartitionBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/BlockingPartitionBenchmark.java
@@ -52,7 +52,7 @@ public class BlockingPartitionBenchmark extends BenchmarkBase {
 			throws RunnerException {
 		Options options = new OptionsBuilder()
 				.verbosity(VerboseMode.NORMAL)
-				.include(".*" + BlockingPartitionBenchmark.class.getSimpleName() + ".*")
+				.include(".*" + BlockingPartitionBenchmark.class.getCanonicalName() + ".*")
 				.build();
 
 		new Runner(options).run();

--- a/src/main/java/org/apache/flink/benchmark/ContinuousFileReaderOperatorBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/ContinuousFileReaderOperatorBenchmark.java
@@ -50,7 +50,7 @@ public class ContinuousFileReaderOperatorBenchmark extends BenchmarkBase {
             throws RunnerException {
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + ContinuousFileReaderOperatorBenchmark.class.getSimpleName() + ".*")
+                .include(".*" + ContinuousFileReaderOperatorBenchmark.class.getCanonicalName() + ".*")
                 .build();
 
         new Runner(options).run();

--- a/src/main/java/org/apache/flink/benchmark/InputBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/InputBenchmark.java
@@ -42,7 +42,7 @@ public class InputBenchmark extends BenchmarkBase {
 		throws RunnerException {
 		Options options = new OptionsBuilder()
 			.verbosity(VerboseMode.NORMAL)
-			.include(".*" + InputBenchmark.class.getSimpleName() + ".*")
+			.include(".*" + InputBenchmark.class.getCanonicalName() + ".*")
 			.build();
 
 		new Runner(options).run();

--- a/src/main/java/org/apache/flink/benchmark/KeyByBenchmarks.java
+++ b/src/main/java/org/apache/flink/benchmark/KeyByBenchmarks.java
@@ -43,7 +43,7 @@ public class KeyByBenchmarks extends BenchmarkBase {
 			throws RunnerException {
 		Options options = new OptionsBuilder()
 				.verbosity(VerboseMode.NORMAL)
-				.include(".*" + KeyByBenchmarks.class.getSimpleName() + ".*")
+				.include(".*" + KeyByBenchmarks.class.getCanonicalName() + ".*")
 				.build();
 
 		new Runner(options).run();

--- a/src/main/java/org/apache/flink/benchmark/MemoryStateBackendBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/MemoryStateBackendBenchmark.java
@@ -46,7 +46,7 @@ public class MemoryStateBackendBenchmark extends StateBackendBenchmarkBase {
 			throws RunnerException {
 		Options options = new OptionsBuilder()
 				.verbosity(VerboseMode.NORMAL)
-				.include(".*" + MemoryStateBackendBenchmark.class.getSimpleName() + ".*")
+				.include(".*" + MemoryStateBackendBenchmark.class.getCanonicalName() + ".*")
 				.build();
 
 		new Runner(options).run();

--- a/src/main/java/org/apache/flink/benchmark/RocksStateBackendBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/RocksStateBackendBenchmark.java
@@ -49,7 +49,7 @@ public class RocksStateBackendBenchmark extends StateBackendBenchmarkBase {
 			throws RunnerException {
 		Options options = new OptionsBuilder()
 				.verbosity(VerboseMode.NORMAL)
-				.include(".*" + RocksStateBackendBenchmark.class.getSimpleName() + ".*")
+				.include(".*" + RocksStateBackendBenchmark.class.getCanonicalName() + ".*")
 				.build();
 
 		new Runner(options).run();

--- a/src/main/java/org/apache/flink/benchmark/SerializationFrameworkMiniBenchmarks.java
+++ b/src/main/java/org/apache/flink/benchmark/SerializationFrameworkMiniBenchmarks.java
@@ -52,7 +52,7 @@ public class SerializationFrameworkMiniBenchmarks extends BenchmarkBase {
 	public static void main(String[] args) throws RunnerException {
 		Options options = new OptionsBuilder()
 				.verbosity(VerboseMode.NORMAL)
-				.include(".*" + SerializationFrameworkMiniBenchmarks.class.getSimpleName() + ".*")
+				.include(".*" + SerializationFrameworkMiniBenchmarks.class.getCanonicalName() + ".*")
 				.build();
 
 		new Runner(options).run();

--- a/src/main/java/org/apache/flink/benchmark/TwoInputBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/TwoInputBenchmark.java
@@ -46,7 +46,7 @@ public class TwoInputBenchmark extends BenchmarkBase {
 		throws RunnerException {
 		Options options = new OptionsBuilder()
 			.verbosity(VerboseMode.NORMAL)
-			.include(".*" + TwoInputBenchmark.class.getSimpleName() + ".*")
+			.include(".*" + TwoInputBenchmark.class.getCanonicalName() + ".*")
 			.build();
 
 		new Runner(options).run();

--- a/src/main/java/org/apache/flink/benchmark/WindowBenchmarks.java
+++ b/src/main/java/org/apache/flink/benchmark/WindowBenchmarks.java
@@ -48,7 +48,7 @@ public class WindowBenchmarks extends BenchmarkBase {
 			throws RunnerException {
 		Options options = new OptionsBuilder()
 				.verbosity(VerboseMode.NORMAL)
-				.include(".*" + WindowBenchmarks.class.getSimpleName() + ".*")
+				.include(".*" + WindowBenchmarks.class.getCanonicalName() + ".*")
 				.build();
 
 		new Runner(options).run();

--- a/src/main/java/org/apache/flink/benchmark/full/PojoSerializationBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/full/PojoSerializationBenchmark.java
@@ -79,7 +79,7 @@ public class PojoSerializationBenchmark extends BenchmarkBase {
             throws RunnerException {
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + PojoSerializationBenchmark.class.getSimpleName() + ".*")
+                .include(".*" + PojoSerializationBenchmark.class.getCanonicalName() + ".*")
                 .build();
 
         new Runner(options).run();

--- a/src/main/java/org/apache/flink/benchmark/full/SerializationFrameworkAllBenchmarks.java
+++ b/src/main/java/org/apache/flink/benchmark/full/SerializationFrameworkAllBenchmarks.java
@@ -45,7 +45,7 @@ public class SerializationFrameworkAllBenchmarks extends SerializationFrameworkM
 	public static void main(String[] args) throws RunnerException {
 		Options options = new OptionsBuilder()
 				.verbosity(VerboseMode.NORMAL)
-				.include(".*" + SerializationFrameworkAllBenchmarks.class.getSimpleName() + ".*")
+				.include(".*" + SerializationFrameworkAllBenchmarks.class.getCanonicalName() + ".*")
 				.build();
 
 		new Runner(options).run();

--- a/src/main/java/org/apache/flink/benchmark/full/StringSerializationBenchmark.java
+++ b/src/main/java/org/apache/flink/benchmark/full/StringSerializationBenchmark.java
@@ -30,7 +30,7 @@ public class StringSerializationBenchmark extends BenchmarkBase {
             throws RunnerException {
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + StringSerializationBenchmark.class.getSimpleName() + ".*")
+                .include(".*" + StringSerializationBenchmark.class.getCanonicalName() + ".*")
                 .build();
 
         new Runner(options).run();

--- a/src/main/java/org/apache/flink/state/benchmark/ListStateBenchmark.java
+++ b/src/main/java/org/apache/flink/state/benchmark/ListStateBenchmark.java
@@ -56,7 +56,7 @@ public class ListStateBenchmark extends StateBenchmarkBase {
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + ListStateBenchmark.class.getSimpleName() + ".*")
+                .include(".*" + ListStateBenchmark.class.getCanonicalName() + ".*")
                 .build();
 
         new Runner(opt).run();

--- a/src/main/java/org/apache/flink/state/benchmark/MapStateBenchmark.java
+++ b/src/main/java/org/apache/flink/state/benchmark/MapStateBenchmark.java
@@ -52,7 +52,7 @@ public class MapStateBenchmark extends StateBenchmarkBase {
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + MapStateBenchmark.class.getSimpleName() + ".*")
+                .include(".*" + MapStateBenchmark.class.getCanonicalName() + ".*")
                 .build();
 
         new Runner(opt).run();

--- a/src/main/java/org/apache/flink/state/benchmark/ValueStateBenchmark.java
+++ b/src/main/java/org/apache/flink/state/benchmark/ValueStateBenchmark.java
@@ -45,7 +45,7 @@ public class ValueStateBenchmark extends StateBenchmarkBase {
     public static void main(String[] args) throws RunnerException {
         Options opt = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + ValueStateBenchmark.class.getSimpleName() + ".*")
+                .include(".*" + ValueStateBenchmark.class.getCanonicalName() + ".*")
                 .build();
 
         new Runner(opt).run();

--- a/src/test/java/org/apache/flink/benchmark/DataSkewStreamNetworkThroughputBenchmarkExecutor.java
+++ b/src/test/java/org/apache/flink/benchmark/DataSkewStreamNetworkThroughputBenchmarkExecutor.java
@@ -45,7 +45,7 @@ public class DataSkewStreamNetworkThroughputBenchmarkExecutor extends BenchmarkB
 			throws RunnerException {
 		Options options = new OptionsBuilder()
 				.verbosity(VerboseMode.NORMAL)
-				.include(".*" + DataSkewStreamNetworkThroughputBenchmarkExecutor.class.getSimpleName() + ".*")
+				.include(".*" + DataSkewStreamNetworkThroughputBenchmarkExecutor.class.getCanonicalName() + ".*")
 				.build();
 
 		new Runner(options).run();

--- a/src/test/java/org/apache/flink/benchmark/StreamNetworkBroadcastThroughputBenchmarkExecutor.java
+++ b/src/test/java/org/apache/flink/benchmark/StreamNetworkBroadcastThroughputBenchmarkExecutor.java
@@ -45,7 +45,7 @@ public class StreamNetworkBroadcastThroughputBenchmarkExecutor extends Benchmark
 			throws RunnerException {
 		Options options = new OptionsBuilder()
 				.verbosity(VerboseMode.NORMAL)
-				.include(".*" + StreamNetworkBroadcastThroughputBenchmarkExecutor.class.getSimpleName() + ".*")
+				.include(".*" + StreamNetworkBroadcastThroughputBenchmarkExecutor.class.getCanonicalName() + ".*")
 				.build();
 
 		new Runner(options).run();

--- a/src/test/java/org/apache/flink/benchmark/StreamNetworkLatencyBenchmarkExecutor.java
+++ b/src/test/java/org/apache/flink/benchmark/StreamNetworkLatencyBenchmarkExecutor.java
@@ -49,7 +49,7 @@ public class StreamNetworkLatencyBenchmarkExecutor extends BenchmarkBase {
 			throws RunnerException {
 		Options options = new OptionsBuilder()
 				.verbosity(VerboseMode.NORMAL)
-				.include(".*" + StreamNetworkLatencyBenchmarkExecutor.class.getSimpleName() + ".*")
+				.include(".*" + StreamNetworkLatencyBenchmarkExecutor.class.getCanonicalName() + ".*")
 				.build();
 
 		new Runner(options).run();

--- a/src/test/java/org/apache/flink/benchmark/StreamNetworkThroughputBenchmarkExecutor.java
+++ b/src/test/java/org/apache/flink/benchmark/StreamNetworkThroughputBenchmarkExecutor.java
@@ -52,7 +52,7 @@ public class StreamNetworkThroughputBenchmarkExecutor extends BenchmarkBase {
 			throws RunnerException {
 		Options options = new OptionsBuilder()
 				.verbosity(VerboseMode.NORMAL)
-				.include(".*" + StreamNetworkThroughputBenchmarkExecutor.class.getSimpleName() + ".*")
+				.include(".*" + StreamNetworkThroughputBenchmarkExecutor.class.getCanonicalName() + ".*")
 				.build();
 
 		new Runner(options).run();


### PR DESCRIPTION
Each benchmark class is accompanied by an according `public static main (String[] args)` method which should run all benchmarks in that class. However, it just uses the class' simple name in a regexp like `".*<name>.*"` and may thus also match further classes that were not intended to run. An example for this is the `StreamNetworkThroughputBenchmarkExecutor` which also runs benchmarks from `DataSkewStreamNetworkThroughputBenchmarkExecutor`. Using the canonical name instead fixes that behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dataartisans/flink-benchmarks/55)
<!-- Reviewable:end -->
