### PR TITLE
 [FLINK-17057][network] add OpenSSL-based benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ We also support to run each benchmark once (with only one fork and one iteration
 mvn test -P test
 ```
 
+## Prerequisites
+
+The recent addition of OpenSSL-based benchmarks require one of two modes to be active:
+- dynamically-linked OpenSSL (default): this uses a dependency with native wrappers that are linked dynamically to your system's libraries. Depending on the installed OpenSSL version and OS, this may fail and you should try the next option:
+- statically-linked OpenSSL: this can be activated by `mvn -Dinclude-netty-tcnative-static` but requires `flink-shaded-netty-tcnative-static` in the version from `pom.xml` which can be generated from inside a corresponding flink-shaded source via:
+```
+mvn clean install -Pinclude-netty-tcnative-static -pl flink-shaded-netty-tcnative-static
+```
+
+If both options are not working, OpenSSL benchmarks will fail but that should not influence any other benchmarks.
+
 ## Code structure
 
 Recommended code structure is to define all benchmarks in [Apache Flink](https://github.com/apache/flink)

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@ under the License.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<flink.version>1.11-SNAPSHOT</flink.version>
+		<flink.shaded.version>10.0</flink.shaded.version>
+		<netty.tcnative.version>2.0.25.Final</netty.tcnative.version>
 		<java.version>1.8</java.version>
 		<scala.binary.version>2.11</scala.binary.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
@@ -396,6 +398,44 @@ under the License.
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+
+		<!--
+            This module is not provided by Apache Flink by default due to licensing issues
+            https://issues.apache.org/jira/browse/LEGAL-393
+            It can be used instead of relying on dynamically-linked OpenSSL libs by building
+            it manually in flink-shaded:
+            > mvn clean install -Pinclude-netty-tcnative-static -pl flink-shaded-netty-tcnative-static
+        -->
+		<profile>
+			<id>include-netty-tcnative-static</id>
+			<activation>
+				<property>
+					<name>include-netty-tcnative-static</name>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-shaded-netty-tcnative-static</artifactId>
+					<version>${netty.tcnative.version}-${flink.shaded.version}</version>
+				</dependency>
+			</dependencies>
+		</profile>
+		<profile>
+			<id>include-netty-tcnative-dynamic</id>
+			<activation>
+				<property>
+					<name>!include-netty-tcnative-static</name>
+				</property>
+			</activation>
+			<dependencies>
+				<dependency>
+					<groupId>org.apache.flink</groupId>
+					<artifactId>flink-shaded-netty-tcnative-dynamic</artifactId>
+					<version>${netty.tcnative.version}-${flink.shaded.version}</version>
+				</dependency>
+			</dependencies>
 		</profile>
 	</profiles>
 


### PR DESCRIPTION
This PR and adds OpenSSL network benchmarks:

These can be executed either with dynamically-linked OpenSSL libraries or
statically-linked (and manually-provided) ones. Instructions are in README.md.

Current results on my PC:
- JDK 8:
```
Benchmark                                                   (channelsFlushTimeout)   Mode  Cnt      Score     Error   Units
StreamNetworkThroughputBenchmarkExecutor.networkThroughput          1000,100ms,SSL  thrpt   30  11760.342 ± 282.592  ops/ms
StreamNetworkThroughputBenchmarkExecutor.networkThroughput      1000,100ms,OpenSSL  thrpt   30  27889.053 ± 893.833  ops/ms
```
- JDK11:
```
Benchmark                                                   (channelsFlushTimeout)   Mode  Cnt      Score     Error   Units
StreamNetworkThroughputBenchmarkExecutor.networkThroughput          1000,100ms,SSL  thrpt   30  20628.476 ± 628.461  ops/ms
StreamNetworkThroughputBenchmarkExecutor.networkThroughput      1000,100ms,OpenSSL  thrpt   30  27289.926 ± 962.960  ops/ms
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dataartisans/flink-benchmarks/56)
<!-- Reviewable:end -->
