### PR TITLE
[FLINK-17703][mvn] fix 'benchmark' profile not active by default anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ mvn test -P test
 
 The recent addition of OpenSSL-based benchmarks require one of two modes to be active:
 - dynamically-linked OpenSSL (default): this uses a dependency with native wrappers that are linked dynamically to your system's libraries. Depending on the installed OpenSSL version and OS, this may fail and you should try the next option:
-- statically-linked OpenSSL: this can be activated by `mvn -Dinclude-netty-tcnative-static` but requires `flink-shaded-netty-tcnative-static` in the version from `pom.xml` which can be generated from inside a corresponding flink-shaded source via:
+- statically-linked OpenSSL: this can be activated by `mvn -Dnetty-tcnative.flavor=static` but requires `flink-shaded-netty-tcnative-static` in the version from `pom.xml`. This module is not provided by Apache Flink by default due to licensing issues (see https://issues.apache.org/jira/browse/LEGAL-393) but can be generated from inside a corresponding `flink-shaded` source via:
 ```
 mvn clean install -Pinclude-netty-tcnative-static -pl flink-shaded-netty-tcnative-static
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@ under the License.
 		<chill.version>0.7.6</chill.version>
 		<thrift.version>0.13.0</thrift.version>
 		<protobuf.version>3.11.4</protobuf.version>
+		<netty-tcnative.flavor>dynamic</netty-tcnative.flavor>
 	</properties>
 
 	<repositories>
@@ -183,6 +184,12 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-cep_${scala.binary.version}</artifactId>
 			<version>${flink.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-netty-tcnative-${netty-tcnative.flavor}</artifactId>
+			<version>${netty.tcnative.version}-${flink.shaded.version}</version>
 		</dependency>
 
 		<dependency>
@@ -398,44 +405,6 @@ under the License.
 					</plugin>
 				</plugins>
 			</build>
-		</profile>
-
-		<!--
-            This module is not provided by Apache Flink by default due to licensing issues
-            https://issues.apache.org/jira/browse/LEGAL-393
-            It can be used instead of relying on dynamically-linked OpenSSL libs by building
-            it manually in flink-shaded:
-            > mvn clean install -Pinclude-netty-tcnative-static -pl flink-shaded-netty-tcnative-static
-        -->
-		<profile>
-			<id>include-netty-tcnative-static</id>
-			<activation>
-				<property>
-					<name>include-netty-tcnative-static</name>
-				</property>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-shaded-netty-tcnative-static</artifactId>
-					<version>${netty.tcnative.version}-${flink.shaded.version}</version>
-				</dependency>
-			</dependencies>
-		</profile>
-		<profile>
-			<id>include-netty-tcnative-dynamic</id>
-			<activation>
-				<property>
-					<name>!include-netty-tcnative-static</name>
-				</property>
-			</activation>
-			<dependencies>
-				<dependency>
-					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-shaded-netty-tcnative-dynamic</artifactId>
-					<version>${netty.tcnative.version}-${flink.shaded.version}</version>
-				</dependency>
-			</dependencies>
 		</profile>
 	</profiles>
 


### PR DESCRIPTION
This adapts the profiles to include the netty-tcnative dependency set via the
'netty-tcnative.flavor' property which can be overridden for the
statically-linked library if needed. The dynamically-linked dependency does not
need another profile activation and thus 'benchmark' is active by default again.

The following two commands run a benchmark in the two different modes for OpenSSL:
```
mvn -Dflink.version=1.11-SNAPSHOT exec:exec
```

```
mvn -Dflink.version=1.11-SNAPSHOT exec:exec -Dnetty-tcnative.flavor=static
```
 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dataartisans/flink-benchmarks/59)
<!-- Reviewable:end -->
