### PR TITLE
[FLINK-17704][mvn] allow execution of arbitrary benchmarks via a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ benchmark suite to define runners to execute those test cases. You can execute t
 default benchmark suite (which takes ~1hour) at once:
 
 ```
-mvn -Dflink.version=1.5.0 clean install exec:exec
+mvn -Dflink.version=1.11-SNAPSHOT clean install exec:exec
 ```
 
 There is also a separate benchmark suit for state backend, and you can execute this suit (which takes ~1hour) using
 below command:
 
 ```
-mvn -Dflink.version=1.5.0 clean package exec:exec \
+mvn -Dflink.version=1.11-SNAPSHOT clean package exec:exec \
  -Dbenchmarks="org.apache.flink.state.benchmark.*"
 ```
 
@@ -28,7 +28,7 @@ There're mainly two ways:
 
 2. From command line, using command like:
    ```
-   mvn -Dflink.version=1.5.0 clean package exec:exec \
+   mvn -Dflink.version=1.11-SNAPSHOT clean package exec:exec \
     -Dbenchmarks="<benchmark_class>"
    ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ below command:
 
 ```
 mvn -Dflink.version=1.5.0 clean package exec:exec \
- -Dexec.executable=java -Dexec.args="-jar target/benchmarks.jar -rf csv org.apache.flink.state.benchmark.*"
+ -Dbenchmarks="org.apache.flink.state.benchmark.*"
 ```
 
 If you want to execute just one benchmark, the best approach is to execute selected main function manually.
@@ -29,7 +29,7 @@ There're mainly two ways:
 2. From command line, using command like:
    ```
    mvn -Dflink.version=1.5.0 clean package exec:exec \
-    -Dexec.executable=java -Dexec.args="-jar target/benchmarks.jar <benchmark_class>"
+    -Dbenchmarks="<benchmark_class>"
    ```
 
 We also support to run each benchmark once (with only one fork and one iteration) for testing, with below command:

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@ under the License.
 		<thrift.version>0.13.0</thrift.version>
 		<protobuf.version>3.11.4</protobuf.version>
 		<netty-tcnative.flavor>dynamic</netty-tcnative.flavor>
+		<benchmarkExcludes>org.apache.flink.benchmark.full.*,org.apache.flink.state.benchmark.*</benchmarkExcludes>
+		<benchmarks>.*</benchmarks>
 	</properties>
 
 	<repositories>
@@ -304,6 +306,9 @@ under the License.
 			<id>benchmark</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
+				<property>
+					<name>benchmarks</name>
+				</property>
 			</activation>
 			<build>
 				<plugins>
@@ -327,10 +332,10 @@ under the License.
 								<classpath/>
 								<argument>org.openjdk.jmh.Main</argument>
 								<argument>-e</argument>
-								<argument>org.apache.flink.benchmark.full.*,org.apache.flink.state.benchmark.*</argument>
+								<argument>${benchmarkExcludes}</argument>
 								<argument>-rf</argument>
 								<argument>csv</argument>
-								<argument>.*</argument>
+								<argument>${benchmarks}</argument>
 							</arguments>
 						</configuration>
 					</plugin>
@@ -366,6 +371,17 @@ under the License.
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>custom-benchmark</id>
+			<activation>
+				<property>
+					<name>benchmarks</name>
+				</property>
+			</activation>
+			<properties>
+				<benchmarkExcludes>""</benchmarkExcludes>
+			</properties>
 		</profile>
 
 		<profile>


### PR DESCRIPTION
This is based on #59 and adds a simple way of executing an arbitrary subset of benchmarks, e.g.

```
mvn -Dflink.version=1.11-SNAPSHOT exec:exec -Dbenchmarks="org.apache.flink.benchmark.StreamNetworkThroughputBenchmarkExecutor"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dataartisans/flink-benchmarks/60)
<!-- Reviewable:end -->
