### PR TITLE
[FLINK-16057] Don't end input in ContinuousFileReaderOperator Benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ install:
 # files. The "mvn install" command will run by default during the "install"
 # phase by Travis, without the profile flag. Here we customize the install
 # phase to use the relevant profile.
-- mvn install -P test -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+# https.protocols is a workaround for https://bugs.openjdk.java.net/browse/JDK-8213202
+- mvn install -P test -DskipTests=true -Dmaven.javadoc.skip=true -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 -B -V
 script:
 - mvn test -P test -B


### PR DESCRIPTION
Currently, END_OF_INPUT is sent once all splits were emitted.
Thus, all subsequent reads in ContinuousFileReaderOperator are made in
CLOSING state in a simple loop (MailboxExecutor.isIdle is always true).
Which is not a scenario this benchmark is intended for.

This change makes source to wait until all elements reach sink.